### PR TITLE
Swap in structopt to get -h/--help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,33 +3,24 @@
 version = 3
 
 [[package]]
-name = "argh"
-version = "0.1.6"
+name = "ansi_term"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f023c76cd7975f9969f8e29f0e461decbdc7f51048ce43427107a3d192f1c9bf"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "argh_derive",
- "argh_shared",
+ "winapi",
 ]
 
 [[package]]
-name = "argh_derive"
-version = "0.1.6"
+name = "atty"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ad219abc0c06ca788aface2e3a1970587e3413ab70acd20e54b6ec524c1f8f"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "argh_shared",
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
-
-[[package]]
-name = "argh_shared"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38de00daab4eac7d753e97697066238d67ce9d7e2d823ab4f72fe14af29f3f33"
 
 [[package]]
 name = "autocfg"
@@ -78,6 +69,21 @@ checksum = "de6836a1b6197d8acdaac74a01af077a26aa6953d2e9251eef061c646b0d432c"
 dependencies = [
  "half",
  "serde",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -160,6 +166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +223,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "linked-hash-map"
@@ -371,7 +392,6 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 name = "reserde"
 version = "0.0.2"
 dependencies = [
- "argh",
  "bincode",
  "cargo-husky",
  "ciborium",
@@ -386,6 +406,7 @@ dependencies = [
  "serde_taml",
  "serde_urlencoded",
  "serde_yaml",
+ "structopt",
  "strum",
  "syn",
  "tap",
@@ -549,6 +570,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strum"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +655,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "tinyvec"
@@ -683,6 +743,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version-sync"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +798,28 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ is-it-maintained-open-issues = { repository = "Tamschi/reserde" }
 maintenance = { status = "experimental" } # This may differ between branches.
 
 [dependencies]
-argh = "0.1.6"
 bincode = "1.3.1"
 quick-xml = { version = "0.22.0", features = ["serialize"] }
 serde = "1.0.130"
@@ -41,6 +40,7 @@ serde_urlencoded = "0.7.0"
 serde_yaml = "0.8.21"
 serde-object = "0.0.0-alpha.0"
 serde-detach = "0.0.1"
+structopt = "0.3.23"
 strum = { version = "0.22.0", features = ["derive"] }
 tap = "1.0.1"
 ciborium = "0.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/reserde/0.0.2")]
 #![warn(clippy::pedantic)]
 
-use argh::FromArgs;
 use serde_detach::detach;
 use serde_object::Object;
 use std::{
@@ -10,47 +9,49 @@ use std::{
 	io::{stdin, stdout, Read as _, Write as _},
 	path::PathBuf,
 };
-use strum::EnumString;
+use structopt::StructOpt;
+use strum::{EnumString, EnumVariantNames, VariantNames};
 use tap::Pipe as _;
 
-#[derive(Debug, FromArgs)]
+#[derive(Debug, StructOpt)]
+#[structopt(name = "reserde")]
 /// Transcode a self-describing format into a different format.
 ///
 /// Currently supports Bencode, Bincode (--out only), CBOR, JSON (--pretty), TAML (--in only), XML, x-www-form-urlencoded (as urlencoded) and YAML.
 /// All names are lowercase.
 struct Args {
-	#[argh(option, long = "if")]
+	#[structopt(long = "if")]
 	/// where to read input from. Defaults to stdin
 	in_file: Option<PathBuf>,
 
-	#[argh(option, long = "of")]
+	#[structopt(long = "of")]
 	/// where to write output to. Defaults to stdout
 	out_file: Option<PathBuf>,
 
 	//TODO: List In variant.
-	#[argh(option, short = 'i', long = "in")]
+	#[structopt(short = "i", long = "in", possible_values = In::VARIANTS)]
 	/// what to read
 	in_format: In,
 
 	//TODO: List Out variant.
-	#[argh(option, short = 'o', long = "out")]
+	#[structopt(short = "o", long = "out", possible_values = Out::VARIANTS)]
 	/// what to write
 	out_format: Out,
 
-	#[argh(switch, short = 'p')]
+	#[structopt(short = "p")]
 	/// pretty-print (where supported)
 	pretty: bool,
 
-	#[argh(option, short = 's')]
+	#[structopt(short = "s")]
 	/// stringify bytes and non-string value keys into strings where possible, possible values are: utf8. (Tries encodings in the order specified.) [try with: --in bencode]
 	stringify: Vec<Encoding>,
 
-	#[argh(switch)]
+	#[structopt(long = "enum-bools")]
 	/// case-insensitively convert unit variants with name `true` or `false` into booleans.
 	enum_bools: bool,
 }
 
-#[derive(Debug, EnumString, Clone, Copy)]
+#[derive(Debug, EnumString, EnumVariantNames, Clone, Copy)]
 enum In {
 	#[strum(serialize = "bencode")]
 	Bencode,
@@ -74,7 +75,7 @@ enum In {
 	Yaml,
 }
 
-#[derive(Debug, EnumString, Clone, Copy)]
+#[derive(Debug, EnumString, EnumVariantNames, Clone, Copy)]
 enum Out {
 	#[strum(serialize = "bencode")]
 	Bencode,
@@ -106,7 +107,7 @@ enum Encoding {
 
 #[allow(clippy::too_many_lines)]
 fn main() {
-	let args: Args = argh::from_env();
+	let args: Args = StructOpt::from_args();
 
 	//TODO: Avoid leaking.
 


### PR DESCRIPTION
Add the short version of help by switching to structopt flag by switching the argument parsing to structopt to fix #30 