### PR TITLE
Remove comment left in code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 <!-- markdownlint-disable no-trailing-punctuation -->
 
-## 0.0.3
+## next
 
-- Features
-  - `-h` made alternate option to display help.
-  - in/out now show valid choices with --help command.
+TODO: Date
+
+- Features:
+  - `-h` made alternate option to display help. (contributed by @scribe in #31 and #32)
+    > This is implemented by switching to `structopt` for argument parsing.  
+    > Additionally, `--in` and `--out` now show valid choices with the `-h`/`--help` command.
 
 ## 0.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- markdownlint-disable no-trailing-punctuation -->
 
+## 0.0.3
+
+- Features
+  - `-h` made alternate option to display help.
+  - in/out now show valid choices with --help command.
+
 ## 0.0.2
 
 2021-08-01

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -187,7 +187,7 @@
       identification within third-party archives.
 
    Copyright 2020-2021 Tamme Schichler <tamme@schichler.dev>
-   Copyright 2020-2021 Eric Bergstrom <192110+scribe@users.noreply.github.com>
+   Copyright 2020-2021 Eric Bergstrom <scribegithub@gmail.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -187,6 +187,7 @@
       identification within third-party archives.
 
    Copyright 2020-2021 Tamme Schichler <tamme@schichler.dev>
+   Copyright 2020-2021 Eric Bergstrom <192110+scribe@users.noreply.github.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2020-2021 Tamme Schichler <tamme@schichler.dev>
+Copyright (c) 2020-2021 Eric Bergstrom <192110+scribe@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2020-2021 Tamme Schichler <tamme@schichler.dev>
-Copyright (c) 2020-2021 Eric Bergstrom <192110+scribe@users.noreply.github.com>
+Copyright (c) 2020-2021 Eric Bergstrom <scribegithub@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -32,22 +32,45 @@ reserde --help
 ```
 
 ```txt
-Usage: reserde.exe [--if <if>] [--of <of>] -i <in> -o <out> [-p] [-s <stringify...>] [--enum-bools]
+reserde 0.0.2
+Transcode a self-describing format into a different format.
 
-Transcode a self-describing format into a different format. Currently supports Bencode, Bincode (--out only), CBOR, JSON (--pretty), TAML (--in only), XML, x-www-form-urlencoded (as urlencoded) and YAML. All names are lowercase.
+Currently supports Bencode, Bincode (--out only), CBOR, JSON (--pretty), TAML (--in only), XML, x-www-form-urlencoded
+(as urlencoded) and YAML. All names are lowercase.
 
-Options:
-  --if              where to read input from. Defaults to stdin
-  --of              where to write output to. Defaults to stdout
-  -i, --in          what to read
-  -o, --out         what to write
-  -p, --pretty      pretty-print (where supported)
-  -s, --stringify   stringify bytes and non-string value keys into strings where
-                    possible, possible values are: utf8. (Tries encodings in the
-                    order specified.) [try with: --in bencode]
-  --enum-bools      case-insensitively convert unit variants with name `true` or
-                    `false` into booleans.
-  --help            display usage information
+USAGE:
+    reserde [FLAGS] [OPTIONS] --in <in-format> --out <out-format>
+
+FLAGS:
+        --enum-bools
+            case-insensitively convert unit variants with name `true` or `false` into booleans
+
+    -h, --help
+            Prints help information
+
+    -p
+            pretty-print (where supported)
+
+    -V, --version
+            Prints version information
+
+
+OPTIONS:
+        --if <in-file>
+            where to read input from. Defaults to stdin
+
+    -i, --in <in-format>
+            what to read [possible values: bencode, cbor, json, taml, urlencoded, xml, yaml]
+
+        --of <out-file>
+            where to write output to. Defaults to stdout
+
+    -o, --out <out-format>
+            what to write [possible values: bencode, bincode, cbor, json, urlencoded, xml, yaml]
+
+    -s <stringify>...
+            stringify bytes and non-string value keys into strings where possible, possible values are: utf8. (Tries
+            encodings in the order specified.) [try with: --in bencode]
 ```
 
 ## Examples

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,11 @@ struct Args {
 	/// where to write output to. Defaults to stdout
 	out_file: Option<PathBuf>,
 
-	//TODO: List In variant.
-	#[structopt(short = "i", long = "in", possible_values = In::VARIANTS)]
+	#[structopt(short = "i", long = "in", possible_values = In::VARIANTS, help="input format")]
 	/// what to read
 	in_format: In,
 
-	//TODO: List Out variant.
-	#[structopt(short = "o", long = "out", possible_values = Out::VARIANTS)]
+	#[structopt(short = "o", long = "out", possible_values = Out::VARIANTS, help="output format")]
 	/// what to write
 	out_format: Out,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,11 +28,11 @@ struct Args {
 	/// where to write output to. Defaults to stdout
 	out_file: Option<PathBuf>,
 
-	#[structopt(short = "i", long = "in", possible_values = In::VARIANTS, help="input format")]
+	#[structopt(short = "i", long = "in", possible_values = In::VARIANTS)]
 	/// what to read
 	in_format: In,
 
-	#[structopt(short = "o", long = "out", possible_values = Out::VARIANTS, help="output format")]
+	#[structopt(short = "o", long = "out", possible_values = Out::VARIANTS)]
 	/// what to write
 	out_format: Out,
 


### PR DESCRIPTION
This is pretty trivial, but I didn't realize structopt would include the possible values until I played with it more later.

This PR removes two comments that are no longer accurate after #31. My bad for leaving comments like that.